### PR TITLE
feat: Add build command and export to .db for mdxdb

### DIFF
--- a/examples/mdxdb-build-example/content/articles/article1.mdx
+++ b/examples/mdxdb-build-example/content/articles/article1.mdx
@@ -1,0 +1,9 @@
+---
+title: My First Article
+date: 2024-01-15
+description: This is the first article in our example.
+---
+
+# Hello World
+
+This is the body of the first article.

--- a/examples/mdxdb-build-example/content/articles/article2.mdx
+++ b/examples/mdxdb-build-example/content/articles/article2.mdx
@@ -1,0 +1,9 @@
+---
+title: Another Exciting Post
+date: 2024-01-20
+description: More content to showcase mdxdb.
+---
+
+## Second Article Insights
+
+Mdxdb makes content management easy!

--- a/examples/mdxdb-build-example/package.json
+++ b/examples/mdxdb-build-example/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mdxdb-build-example",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build-content": "mdxdb build",
+    "show-data": "tsx src/index.ts"
+  },
+  "devDependencies": {
+    "mdxdb": "workspace:*",
+    "tsx": "^4.19.4",
+    "typescript": "^5.8.3"
+  }
+}

--- a/examples/mdxdb-build-example/src/index.ts
+++ b/examples/mdxdb-build-example/src/index.ts
@@ -1,0 +1,23 @@
+import { articles } from '../.db'; // Adjusted path if Velite outputs directly to .db
+                                   // Or from 'mdxdb/.db' if it were a published package and types resolved that way.
+                                   // For local example, direct import from ../.db should work after build-content.
+
+function displayArticles() {
+  if (!articles || articles.length === 0) {
+    console.log("No articles found. Did you run 'pnpm build-content'?");
+    return;
+  }
+
+  console.log('--- Published Articles ---');
+  articles.forEach(article => {
+    console.log(`Title: ${article.title}`);
+    console.log(`Slug: ${article.slug}`);
+    console.log(`Date: ${article.date}`);
+    console.log(`Permalink: ${article.permalink}`);
+    console.log(`Description: ${article.description}`);
+    // console.log(`Body (HTML): ${article.body.substring(0, 50)}...`); // Accessing processed markdown
+    console.log('-------------------------');
+  });
+}
+
+displayArticles();

--- a/examples/mdxdb-build-example/tsconfig.json
+++ b/examples/mdxdb-build-example/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "../.db": ["./.db/index"],
+      "../.db/*": ["./.db/*"]
+    }
+  },
+  "include": ["src/**/*.ts", ".db/**/*.d.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/mdxdb-build-example/velite.config.ts
+++ b/examples/mdxdb-build-example/velite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, s } from 'velite';
+
+const articles = {
+  name: 'Article',
+  pattern: 'content/articles/**/*.mdx',
+  schema: s.object({
+    title: s.string(),
+    slug: s.slug('global', ['title']),
+    date: s.isodate(),
+    description: s.string().optional(),
+    body: s.markdown() // Or s.mdx() if you have MDX specific features
+  }).transform(data => ({ ...data, permalink: `/articles/${data.slug}` }))
+};
+
+export default defineConfig({
+  root: '.', // Velite should operate in the example project's root
+  collections: { articles }
+});

--- a/packages/mdxdb/cli.ts
+++ b/packages/mdxdb/cli.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+import { MdxDb } from './lib/mdxdb.js'; // Use .js extension for ESM imports
+import path from 'path';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+
+  if (command === 'build') {
+    console.log('mdxdb: Starting build process...');
+    try {
+      // Instantiate MdxDb with the current working directory as packageDir
+      // This assumes the CLI is run from the root of the project using mdxdb
+      const mdxDb = new MdxDb(process.cwd());
+
+      await mdxDb.build();
+      console.log('mdxdb: Content build complete.');
+
+      const exportPath = '.db';
+      await mdxDb.exportDb(exportPath);
+      console.log(`mdxdb: Build output successfully exported to ./${path.basename(exportPath)}`);
+      console.log('mdxdb: Build process finished successfully.');
+
+    } catch (error) {
+      console.error('mdxdb: Error during build process:');
+      if (error instanceof Error) {
+        console.error(error.message);
+        if (error.stack) {
+            console.error(error.stack);
+        }
+      } else {
+        console.error(String(error));
+      }
+      process.exit(1); // Exit with error code
+    }
+  } else {
+    console.log('Usage: mdxdb build');
+    if (command) {
+      console.log(`Unknown command: ${command}`);
+      process.exit(1); // Exit with error code for unknown command
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error('mdxdb: An unexpected error occurred:');
+  if (error instanceof Error) {
+    console.error(error.message);
+    if (error.stack) {
+        console.error(error.stack);
+    }
+  } else {
+    console.error(String(error));
+  }
+  process.exit(1);
+});

--- a/packages/mdxdb/package.json
+++ b/packages/mdxdb/package.json
@@ -11,6 +11,21 @@
     "pnpm": "^10.11.0",
     "simple-git": "^3.27.0"
   },
+  "main": "./dist/lib/mdxdb.js",
+  "types": "./.db/index.d.ts",
+  "files": [
+    "dist/lib/",
+    "dist/cli.js",
+    ".db/"
+  ],
+  "bin": {
+    "mdxdb": "./dist/cli.js"
+  },
+  "scripts": {
+    "build:lib": "tsc -p tsconfig.json",
+    "build:cli": "tsc -p tsconfig.cli.json",
+    "build": "pnpm run build:lib && pnpm run build:cli"
+  },
   "devDependencies": {
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",

--- a/packages/mdxdb/tsconfig.cli.json
+++ b/packages/mdxdb/tsconfig.cli.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "module": "NodeNext", // Suitable for ESM with "type": "module"
+    "moduleResolution": "NodeNext", // Or "Bundler"
+    "target": "ES2022", // Modern Node versions support ES2022
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false, // No .d.ts needed for CLI entry point
+    "include": ["cli.ts", "lib/**/*.ts"], // Include CLI and library files
+    "baseUrl": "." // Added to help with path resolution if needed
+  },
+  "exclude": ["node_modules", "dist", ".velite", ".db", "**/*.test.ts", "velite.config.ts"]
+}

--- a/packages/mdxdb/tsconfig.json
+++ b/packages/mdxdb/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/lib", // Output JS files to dist/lib
+    "rootDir": "./lib",     // Source files are in lib
+    "module": "NodeNext",   // For ESM library
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,      // Generate .d.ts files
+    "declarationDir": "./dist/lib", // Place .d.ts files alongside JS files
+    "baseUrl": ".",
+    "paths": {
+      // This might be needed if velite.config depends on aliases not directly resolvable
+      // For now, assume direct relative paths or node_modules resolution works.
+    }
+  },
+  "include": ["lib/**/*.ts"], // Only compile library files
+  "exclude": ["node_modules", "dist", ".velite", ".db", "**/*.test.ts", "cli.ts", "velite.config.ts"]
+}


### PR DESCRIPTION
This commit introduces a new `build` command to the mdxdb CLI.

Key changes:

-   **`MdxDb` Refactor (`packages/mdxdb/lib/mdxdb.ts`):**
    -   The `build()` method now uses `loadDataFromVeliteOutput()` to load all collections dynamically.
    -   `packageDir` is now configurable, defaulting to `.` for better flexibility.
    -   Added `exportDb(targetDir: string)` method to copy Velite's output (e.g., from `.velite/`) to a specified directory (e.g., `.db/`).

-   **CLI Implementation (`packages/mdxdb/cli.ts`):**
    -   Added `mdxdb` executable with a `build` command.
    -   The `build` command:
        1.  Initializes `MdxDb` using `process.cwd()` as the root.
        2.  Executes `mdxDb.build()` to trigger Velite.
        3.  Executes `mdxDb.exportDb('.db')` to save the output to a local `.db` folder.
    -   Includes CLI-specific tsconfig (`tsconfig.cli.json`) and build scripts in `package.json`.

-   **NPM Publishing (`packages/mdxdb/package.json`):**
    -   Configured `bin` field for the `mdxdb` command.
    -   Updated `files` array to include `dist/lib`, `dist/cli.js`, and `.db/`.
    -   Set `main` entry point to `./dist/lib/mdxdb.js`.
    -   Set `types` entry point to `./.db/index.d.ts` to provide types from the Velite build output, as requested.
    -   Added separate `build:lib` and `build:cli` scripts, and a combined `build` script.

-   **Example Project (`examples/mdxdb-build-example/`):**
    -   Created a new example demonstrating the `mdxdb build` workflow.
    -   Includes sample content, `velite.config.ts`, and a script to show how to import and use data from the generated `.db` folder.

This addresses the issue by enabling you to build your MD/MDX content into a `.db` folder using the `mdxdb` CLI and prepares the package for npm publishing with the correct exports and types.