### PR TITLE
Update changesets workflow to only publish after PR approval and merge

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_review:
+    types:
+      - submitted
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,7 +18,7 @@ concurrency:
 jobs:
   release:
     name: Release
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -48,7 +51,7 @@ jobs:
           title: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   check:
     name: Check Changeset


### PR DESCRIPTION
# Update Changesets Workflow to Only Publish After PR Approval and Merge

This PR modifies the changesets workflow to ensure packages are only published to NPM after a PR has been approved and merged to the main branch.

## Changes Made:

1. Added the `pull_request_review` event with type `submitted` to trigger the workflow when a review is submitted
2. Modified the `if` condition for the `release` job to ensure it only runs on pushes to main (which happens after a PR is merged)
3. Uncommented the NPM_TOKEN line to ensure packages can be published to NPM

The existing `check` job will continue to run on PRs to verify changesets.

## Testing:
- No local testing was performed as this is a GitHub workflow configuration change