### PR TITLE
Implement MdxDb watch mode

### DIFF
--- a/packages/mdxdb/README.md
+++ b/packages/mdxdb/README.md
@@ -101,11 +101,13 @@ async function initializeDb() {
 ```
 
 ### `db.watch(): Promise<void>`
-Starts Velite's watch mode. This monitors your content files for changes (additions, updates, deletions) and automatically updates the in-memory database. Velite's output will typically appear in the console.
+Starts Velite's watch mode. Internally this spawns `velite dev --watch` and reloads the database every time Velite finishes a rebuild. The CLI output is piped through so you can see rebuild logs in the console.
 
 ```typescript
 await db.watch();
 console.log('MdxDb is watching for file changes...');
+// ...make edits to your MDX files...
+// call db.stopWatch() when you are done
 ```
 
 ### `db.stopWatch(): void`


### PR DESCRIPTION
## Summary
- implement watch mode with `velite dev --watch`
- document how to use watch mode in the README

## Testing
- `npm run build:lib`
- `npm run build:cli`
- `npm test`