### PR TITLE
Add mdxld validate command

### DIFF
--- a/packages/mdxld/package.json
+++ b/packages/mdxld/package.json
@@ -2,8 +2,12 @@
   "name": "mdxld",
   "type": "module",
   "version": "0.1.0",
+  "bin": {
+    "mdxld": "./dist/cli.js"
+  },
   "dependencies": {
-    "next-mdx-remote-client": "^2.1.2"
+    "next-mdx-remote-client": "^2.1.2",
+    "commander": "^12.1.0"
   },
   "devDependencies": {
     "vitest": "^3.1.4"

--- a/packages/mdxld/src/cli.test.ts
+++ b/packages/mdxld/src/cli.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+
+vi.mock('./parser', () => ({
+  parseFrontmatter: vi.fn(),
+  convertToJSONLD: vi.fn(),
+}))
+
+import { validate } from './cli'
+import { parseFrontmatter, convertToJSONLD } from './parser'
+
+let filePath: string
+
+beforeEach(() => {
+  filePath = path.join(tmpdir(), `mdxld-test-${Date.now()}.mdx`)
+  fs.writeFileSync(filePath, 'content')
+})
+
+afterEach(() => {
+  fs.unlinkSync(filePath)
+  vi.clearAllMocks()
+})
+
+it('returns true when validation succeeds', () => {
+  ;(parseFrontmatter as any).mockReturnValue({ frontmatter: { title: 't' } })
+  ;(convertToJSONLD as any).mockReturnValue({})
+  expect(validate(filePath)).toBe(true)
+  expect(parseFrontmatter).toHaveBeenCalled()
+  expect(convertToJSONLD).toHaveBeenCalled()
+})
+
+it('throws when parseFrontmatter returns an error', () => {
+  ;(parseFrontmatter as any).mockReturnValue({ frontmatter: null, error: 'bad' })
+  expect(() => validate(filePath)).toThrow('bad')
+})
+
+it('throws when convertToJSONLD fails', () => {
+  ;(parseFrontmatter as any).mockReturnValue({ frontmatter: {} })
+  ;(convertToJSONLD as any).mockImplementation(() => {
+    throw new Error('oops')
+  })
+  expect(() => validate(filePath)).toThrow('oops')
+})

--- a/packages/mdxld/src/cli.ts
+++ b/packages/mdxld/src/cli.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { Command } from 'commander'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import packageJson from '../package.json' with { type: 'json' }
+import { parseFrontmatter, convertToJSONLD } from './parser.js'
+
+export function validate(filepath: string): boolean {
+  const fullPath = path.resolve(process.cwd(), filepath)
+  if (!fs.existsSync(fullPath)) {
+    throw new Error(`File not found: ${fullPath}`)
+  }
+
+  const content = fs.readFileSync(fullPath, 'utf-8')
+  const { frontmatter, error } = parseFrontmatter(content)
+  if (!frontmatter || error) {
+    throw new Error(error || 'Invalid frontmatter')
+  }
+
+  try {
+    convertToJSONLD(frontmatter)
+    return true
+  } catch (e: any) {
+    throw new Error(e.message)
+  }
+}
+
+export function run(argv: string[] = process.argv) {
+  const program = new Command()
+  program
+    .name('mdxld')
+    .version(packageJson.version)
+    .description('MDXLD CLI utilities')
+
+  program
+    .command('validate <filepath>')
+    .description('Validate an MDXLD file')
+    .action((filepath: string) => {
+      try {
+        validate(filepath)
+        console.log('Valid MDXLD.')
+      } catch (e: any) {
+        console.error(`Validation failed: ${e.message}`)
+        process.exitCode = 1
+      }
+    })
+
+  program.parse(argv)
+}
+
+const __filename = fileURLToPath(import.meta.url)
+if (process.argv[1] === __filename) {
+  run(process.argv)
+}


### PR DESCRIPTION
## Summary
- implement CLI with `validate` command for mdxld
- expose CLI via bin entry
- unit test validation routine

## Testing
- `pnpm --filter mdxld exec vitest run` *(fails: commander & yaml not found)*