### PR TITLE
Add MDXLD context and docs

### DIFF
--- a/packages/mdxld/README.md
+++ b/packages/mdxld/README.md
@@ -8,3 +8,21 @@
 - Schema definitions for common content types.
 - CLI utilities and bundler plugins for processing MDXLD files.
 - Works with `mdxai`, `mdxdb` and `mdxe` to provide a unified content pipeline.
+
+## JSON-LD Context
+
+The `context` folder contains `mdxld-context.jsonld`, which defines the MDXLD
+namespace and core classes. Reference this file in your frontmatter to enable
+terms like `Component` and `API`:
+
+```yaml
+---
+$context: ./context/mdxld-context.jsonld
+$type: Component
+name: Button
+framework: React
+---
+```
+
+This context also includes `schema.org` so you can freely use standard schema
+properties alongside the MDXLD vocabulary.

--- a/packages/mdxld/context/mdxld-context.jsonld
+++ b/packages/mdxld/context/mdxld-context.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "schema": "https://schema.org/",
+    "mdx": "https://mdxld.org/vocab#",
+
+    "Component": "mdx:Component",
+    "Function": "mdx:Function",
+    "Module": "mdx:Module",
+    "API": "mdx:API",
+    "App": "mdx:App",
+    "Marketplace": "mdx:Marketplace",
+    "Directory": "mdx:Directory",
+    "Service": "mdx:Service"
+  }
+}


### PR DESCRIPTION
## Summary
- add `mdxld/context/mdxld-context.jsonld` with namespace and core classes
- document how to use the context file in `mdxld` README

## Testing
- `npx vitest run` *(fails: Cannot find package 'yaml')*