### PR TITLE
Add basic Button component to mdxui

### DIFF
--- a/packages/mdxui/README.md
+++ b/packages/mdxui/README.md
@@ -15,3 +15,11 @@
 // mdx-components.tsx
 export { useMDXComponents } from 'mdxui'
 ```
+
+```tsx
+import { Button } from 'mdxui'
+
+export default function Example() {
+  return <Button variant='primary'>Click me</Button>
+}
+```

--- a/packages/mdxui/components/button.tsx
+++ b/packages/mdxui/components/button.tsx
@@ -1,0 +1,20 @@
+import type { ButtonHTMLAttributes } from 'react'
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary' | 'text'
+}
+
+export function Button({ variant = 'primary', className = '', ...props }: ButtonProps) {
+  let variantClasses = ''
+  switch (variant) {
+    case 'secondary':
+      variantClasses = 'bg-gray-100 text-gray-900 hover:bg-gray-200'
+      break
+    case 'text':
+      variantClasses = 'bg-transparent text-blue-600 hover:underline'
+      break
+    default:
+      variantClasses = 'bg-blue-600 text-white hover:bg-blue-700'
+  }
+  return <button className={`rounded px-4 py-2 text-sm font-medium ${variantClasses} ${className}`} {...props} />
+}

--- a/packages/mdxui/index.ts
+++ b/packages/mdxui/index.ts
@@ -1,0 +1,3 @@
+export * from './card'
+export * from './gradient'
+export * from './components/button'


### PR DESCRIPTION
## Summary
- create `Button` component with primary, secondary and text variants
- export components from new `index.ts` entry
- document Button usage in the README

## Testing
- `pnpm lint`
- `pnpm test`