### PR TITLE
Add prerelease workflow docs

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,26 @@
+name: Prerelease
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build packages
+        run: pnpm build
+      - name: Publish preview (pkg.pr.new)
+        run: pnpm dlx pkg-pr-new publish './packages/*'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,31 @@
+# Releasing and Preview Workflow
+
+This repository uses [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) to automatically build and publish preview packages.
+
+## Prerelease workflow
+
+Every push or pull request triggers the `prerelease` GitHub Action defined in `.github/workflows/prerelease.yml`.
+The workflow performs the following steps:
+
+1. Checks out the repository.
+2. Installs dependencies with pnpm.
+3. Runs the build for all packages.
+4. Publishes preview packages using `pkg-pr-new publish`.
+
+The pkg.pr.new GitHub App must be installed on the repository so the action can upload preview packages. After a run on a pull request, the bot comments with instructions for installing the preview package, e.g.
+
+```
+npm i https://pkg.pr.new/<package>@<commit-hash>
+```
+
+These prereleases allow testing any commit before an official release.
+
+## Official releases
+
+Stable releases use the `changesets` workflow. When ready, run:
+
+```bash
+pnpm run release
+```
+
+This builds the packages and publishes them to npm with proper versioning.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,6 +23,7 @@ This phase focuses on developing advanced features, improving existing tools, an
 -   **Velite Enhancements:** Enhance the Velite tool for content management with support for mutations (data modifications) and Software Development Kit (SDK) capabilities for programmatic access. (Inspired by `research/velite-mutations.md`)
 -   **Streamlined Next.js Integration:** Improve integration with Next.js, particularly focusing on the `next-mdx-remote-client` for efficient and flexible MDX rendering in Next.js applications. (Inspired by `research/next-mdx-remote-client.md`)
 -   **Comprehensive Packaging and Release Strategy:** Develop a clear and robust packaging and release strategy for the `mdx*` suite of tools, ensuring easy adoption and updates. (Inspired by `research/velite-pkg-pr-new.md`)
+-   **Automated Prerelease Workflow:** Build and publish preview packages for each commit using pkg.pr.new. See `RELEASING.md` for details.
 
 ## Phase 4: Ecosystem Maturation
 


### PR DESCRIPTION
## Summary
- add `prerelease` workflow using pkg.pr.new
- document release process in new `RELEASING.md`
- mention prerelease plan in `ROADMAP.md`

## Testing
- `pnpm run lint`
- `pnpm run check-types` *(fails: getaddrinfo ENOTFOUND fonts.googleapis.com)*
- `pnpm build` *(fails: fonts.googleapis.com)*
- `pnpm test`