### PR TITLE
Add mdxtra zero-config Nextra CLI

### DIFF
--- a/packages/mdxtra/app/app/[[...mdxPath]]/page.tsx
+++ b/packages/mdxtra/app/app/[[...mdxPath]]/page.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { generateStaticParamsFor, importPage } from 'nextra/pages'
+import { useMDXComponents as getMDXComponents } from '../../mdx-components'
+
+export const generateStaticParams = generateStaticParamsFor('mdxPath')
+
+export async function generateMetadata(props: { params: Promise<{ mdxPath: string[] }> }) {
+  const params = await props.params
+  const { metadata } = await importPage(params.mdxPath)
+  return metadata
+}
+
+const Wrapper = getMDXComponents().wrapper
+
+export default async function Page(props: { params: Promise<{ mdxPath: string[] }> }) {
+  const params = await props.params
+  const result = await importPage(params.mdxPath)
+  const { default: MDXContent, toc, metadata } = result
+  return (
+    <Wrapper toc={toc} metadata={metadata}>
+      <MDXContent {...props} params={params} />
+    </Wrapper>
+  )
+}

--- a/packages/mdxtra/app/app/layout.tsx
+++ b/packages/mdxtra/app/app/layout.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Layout } from 'nextra-theme-docs'
+import { Head } from 'nextra/components'
+import { getPageMap } from 'nextra/page-map'
+import 'nextra-theme-docs/style.css'
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang='en' dir='ltr' suppressHydrationWarning>
+      <Head />
+      <body>
+        <Layout pageMap={await getPageMap()}>{children}</Layout>
+      </body>
+    </html>
+  )
+}

--- a/packages/mdxtra/app/mdx-components.js
+++ b/packages/mdxtra/app/mdx-components.js
@@ -1,0 +1,10 @@
+import { useMDXComponents as getThemeComponents } from 'nextra-theme-docs'
+
+const themeComponents = getThemeComponents()
+
+export function useMDXComponents(components) {
+  return {
+    ...themeComponents,
+    ...components,
+  }
+}

--- a/packages/mdxtra/app/next-env.d.ts
+++ b/packages/mdxtra/app/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/mdxtra/app/next.config.mjs
+++ b/packages/mdxtra/app/next.config.mjs
@@ -1,0 +1,10 @@
+import nextra from 'nextra'
+
+const withNextra = nextra({
+  contentDirBasePath: '/',
+})
+
+export default withNextra({
+  experimental: { externalDir: true },
+  pageExtensions: ['md', 'mdx', 'tsx', 'ts', 'jsx', 'js'],
+})

--- a/packages/mdxtra/app/tsconfig.json
+++ b/packages/mdxtra/app/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../config/typescript-config/nextjs.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next.config.mjs",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/mdxtra/bin/mdxtra.js
+++ b/packages/mdxtra/bin/mdxtra.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import fs from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+const [, , cmd = 'dev', ...rest] = process.argv
+const here = dirname(fileURLToPath(import.meta.url))
+const appDir = resolve(here, '../app')
+const link = resolve(appDir, 'content')
+
+await fs.rm(link, { force: true, recursive: true }).catch(() => {})
+await fs.symlink(process.cwd(), link, 'junction')
+
+spawn('node', [require.resolve('next/dist/bin/next'), cmd, appDir, ...rest], { stdio: 'inherit' })

--- a/packages/mdxtra/package.json
+++ b/packages/mdxtra/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mdxtra",
+  "type": "module",
+  "version": "0.1.0",
+  "bin": {
+    "mdxtra": "./bin/mdxtra.js"
+  },
+  "dependencies": {
+    "next": "^15.3.0",
+    "nextra": "^4.2.17",
+    "nextra-theme-docs": "^4.2.17",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
- create `mdxtra` package
- embed Next.js/Nextra site and CLI wrapper

## Testing
- `pnpm test` *(fails: OpenAI API key missing)*
- `pnpm check-types`


------
https://chatgpt.com/codex/tasks/task_e_684aa85fd20483298811ddfcbd3c8496